### PR TITLE
Resolve todos

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -5,13 +5,13 @@ seeds = false
 skip-lint = false
 
 [programs.localnet]
-push_comm = "38y1vrywbkV9xNUBQ2rdi6E1PNxj2EhWgakpN3zLtneu"
+push_comm = "7uczcz9GTYCneGpfNMBT1ccuFBGcLcF1seVGw9utaaw1"
 
 [registry]
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "Localnet"
+cluster = "http://127.0.0.1:8899"
 wallet = "/Users/mdzaryabafser/.config/solana/id.json"
 
 [scripts]

--- a/programs/push_comm/src/events.rs
+++ b/programs/push_comm/src/events.rs
@@ -4,7 +4,7 @@ use anchor_lang::prelude::*;
 #[event]
 pub struct ChannelAlias{
     pub chain_name: String,
-    pub chain_id: u64,
+    pub chain_cluster: String,
     pub channel: Pubkey,
     pub ethereum_channel_address: String,
 }

--- a/programs/push_comm/src/events.rs
+++ b/programs/push_comm/src/events.rs
@@ -5,7 +5,8 @@ use anchor_lang::prelude::*;
 pub struct ChannelAlias{
     pub chain_name: String,
     pub chain_id: u64,
-    pub channel_address: String,
+    pub channel: Pubkey,
+    pub ethereum_channel_address: String,
 }
 #[event]
 pub struct AddDelegate{

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -89,7 +89,8 @@ pub mod push_comm {
         emit!(ChannelAlias {
             chain_name: CHAIN_NAME.to_string(),
             chain_id: storage.chain_id,
-            channel_address: channel_address,
+            channel: ctx.accounts.signer.key(),
+            ethereum_channel_address: channel_address,
         });
         Ok(())
     }
@@ -287,7 +288,10 @@ pub struct AdminStorageUpdateCTX<'info> {
 #[derive(Accounts)]
 pub struct AliasVerificationCTX <'info > {
     #[account(seeds = [PUSH_COMM_STORAGE], bump)]
-    pub storage: Account<'info, PushCommStorageV3>
+    pub storage: Account<'info, PushCommStorageV3>,
+
+    #[account(signer)]
+    pub signer: Signer<'info>,
 }
 
 #[derive(Accounts)]

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -103,7 +103,6 @@ pub mod push_comm {
     }
 
     pub fn subscribe(ctx: Context<SubscriptionCTX>, channel: Pubkey) -> Result<()> {
-        // TO-DO : add + _addUser() function logic here
         _add_user(&mut ctx.accounts.storage, &mut ctx.accounts.comm_storage)?;
         _subscribe(&mut ctx.accounts.storage, &mut ctx.accounts.subscription, ctx.accounts.signer.key(), channel)?;
 
@@ -144,12 +143,20 @@ pub mod push_comm {
     }
 
     // Notification-Specific Functions
-    pub fn add_delegate(ctx: Context<DelegateNotifSenders>,
-        delegate: Pubkey
-    ) -> Result<()>{
-        // TO-DO :added _subscribe() function here
+    pub fn add_delegate(ctx: Context<DelegateNotifSenders>, delegate: Pubkey) -> Result<()> {
         let storage = &mut ctx.accounts.storage;
-        require!( !storage.is_delegate, PushCommError::DelegateAlreadyAdded );
+        require!( !storage.is_delegate, PushCommError::DelegateAlreadyAdded);
+    
+        // Call _add_user to activate the user in comm_storage if necessary
+        _add_user(&mut ctx.accounts.delegate_storage, &mut ctx.accounts.comm_storage)?;
+    
+        // Call _subscribe to subscribe the delegate to the channel
+        _subscribe(
+            &mut ctx.accounts.delegate_storage,
+            &mut ctx.accounts.subscription,
+            delegate,
+            ctx.accounts.signer.key()
+        )?;
 
         storage.channel = ctx.accounts.signer.key();
         storage.delegate = delegate;
@@ -159,6 +166,7 @@ pub mod push_comm {
             channel: ctx.accounts.signer.key(),
             delegate: ctx.accounts.storage.delegate,
         });
+
         Ok(())
     }
 
@@ -343,6 +351,27 @@ pub struct DelegateNotifSenders <'info>{
         seeds = [DELEGATE, signer.key().as_ref(), delegate.key().as_ref()],
         bump )]
     pub storage: Account<'info, DelegatedNotificationSenders>,
+
+    #[account(
+        init_if_needed,
+        payer = signer,
+        space = 8 + 1 + 8 + 8, // discriminator + bool + u64 + u64
+        seeds = [USER_STORAGE, delegate.key().as_ref()],
+        bump
+    )]
+    pub delegate_storage: Account<'info, UserStorage>,
+
+    #[account(
+        init_if_needed,
+        payer = signer,
+        space = 8 + 1, // discriminator + bool
+        seeds = [SUBSCRIPTION, delegate.key().as_ref(), signer.key().as_ref()],
+        bump
+    )]
+    pub subscription: Account<'info, Subscription>,
+    
+    #[account(mut, seeds = [PUSH_COMM_STORAGE], bump)]
+    pub comm_storage: Account<'info, PushCommStorageV3>,
 
     #[account(mut)]
     pub signer: Signer<'info>,

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -30,15 +30,7 @@ pub mod push_comm {
 
 /**
  * ADMIN FUNCTIONS
- */
-    pub fn set_core_address(ctx: Context<AdminStorageUpdateCTX>, //@audit - TBD IF NEEDED 
-        push_core_address: Pubkey,
-        ) -> Result <()> {
-            let storage = &mut ctx.accounts.storage;
-            storage.push_core_address = push_core_address;
-            Ok(())
-        }
-    
+ */ 
     pub fn set_governance_address(ctx: Context<AdminStorageUpdateCTX>,
         governance: Pubkey,
     ) -> Result<()> {

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -19,12 +19,12 @@ pub mod push_comm {
 
     pub fn initialize(ctx: Context<InitializeCTX>, 
         push_admin: Pubkey, 
-        chain_id: u64,
+        chain_cluster: String,
     ) -> Result<()> {
         let storage = &mut ctx.accounts.storage;
         storage.governance = push_admin;
         storage.push_channel_admin = push_admin;
-        storage.chain_id = chain_id;
+        storage.chain_cluster = chain_cluster;
         Ok(())
     }
 
@@ -88,7 +88,7 @@ pub mod push_comm {
 
         emit!(ChannelAlias {
             chain_name: CHAIN_NAME.to_string(),
-            chain_id: storage.chain_id,
+            chain_cluster: storage.chain_cluster.clone(),
             channel: ctx.accounts.signer.key(),
             ethereum_channel_address: channel_address,
         });

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -304,9 +304,6 @@ pub struct SubscriptionCTX<'info> {
         bump
     )]
     pub subscription: Account<'info, Subscription>,
-
-    /// CHECK: This account is not read or written in this instruction
-    pub channel: AccountInfo<'info>,
     
     #[account(mut, seeds = [PUSH_COMM_STORAGE], bump)]
     pub comm_storage: Account<'info, PushCommStorageV3>,

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -105,21 +105,7 @@ pub mod push_comm {
     pub fn subscribe(ctx: Context<SubscriptionCTX>, channel: Pubkey) -> Result<()> {
         // TO-DO : add + _addUser() function logic here
         _add_user(&mut ctx.accounts.storage, &mut ctx.accounts.comm_storage)?;
-        let user = &mut ctx.accounts.storage;
-        let subscription = &mut ctx.accounts.subscription;
-
-        require!(subscription.is_subscribed == false, PushCommError::AlreadySubscribed);
-
-        // Increase user subscribe count by check overflow
-        user.user_subscribe_count += 1;
-        // Mark user as subscribed for a given channel
-        subscription.is_subscribed = true;
-        
-
-        emit!(Subscribed {
-            user: ctx.accounts.signer.key(),
-            channel: ctx.accounts.channel.key(),
-        });
+        _subscribe(&mut ctx.accounts.storage, &mut ctx.accounts.subscription, channel)?;
 
         Ok(())
     }
@@ -244,6 +230,22 @@ fn _add_user(user_storage: &mut Account<UserStorage>, comm_storage: &mut Account
 
         comm_storage.user_count += 1;
     }
+    Ok(())
+}
+
+fn _subscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, channel: Pubkey) -> Result<()> {
+        require!(subscription_storage.is_subscribed == false, PushCommError::AlreadySubscribed);
+
+        // Increase user subscribe count by check overflow
+        user_storage.user_subscribe_count += 1;
+        // Mark user as subscribed for a given channel
+        subscription_storage.is_subscribed = true;
+
+        emit!(Subscribed {
+            user: user_storage.key(),
+            channel: channel,
+        });
+
     Ok(())
 }
 

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -11,7 +11,7 @@ use crate::state::*;
 use crate::errors::*;
 use crate::events::*;
 
-declare_id!("38y1vrywbkV9xNUBQ2rdi6E1PNxj2EhWgakpN3zLtneu");
+declare_id!("7uczcz9GTYCneGpfNMBT1ccuFBGcLcF1seVGw9utaaw1");
 
 #[program]
 pub mod push_comm {
@@ -105,13 +105,13 @@ pub mod push_comm {
     pub fn subscribe(ctx: Context<SubscriptionCTX>, channel: Pubkey) -> Result<()> {
         // TO-DO : add + _addUser() function logic here
         _add_user(&mut ctx.accounts.storage, &mut ctx.accounts.comm_storage)?;
-        _subscribe(&mut ctx.accounts.storage, &mut ctx.accounts.subscription, channel)?;
+        _subscribe(&mut ctx.accounts.storage, &mut ctx.accounts.subscription, ctx.accounts.signer.key(), channel)?;
 
         Ok(())
     }
 
     pub fn unsubscribe(ctx: Context<SubscriptionCTX>, channel: Pubkey) -> Result<()>{
-        _unsubscribe(&mut ctx.accounts.storage, &mut ctx.accounts.subscription, channel)?;
+        _unsubscribe(&mut ctx.accounts.storage, &mut ctx.accounts.subscription, ctx.accounts.signer.key(), channel)?;
 
         Ok(())
     }
@@ -217,7 +217,7 @@ fn _add_user(user_storage: &mut Account<UserStorage>, comm_storage: &mut Account
     Ok(())
 }
 
-fn _subscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, channel: Pubkey) -> Result<()> {
+fn _subscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, user: Pubkey, channel: Pubkey) -> Result<()> {
     require!(subscription_storage.is_subscribed == false, PushCommError::AlreadySubscribed);
 
     // Increase user subscribe count by check overflow
@@ -226,14 +226,14 @@ fn _subscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mu
     subscription_storage.is_subscribed = true;
 
     emit!(Subscribed {
-        user: user_storage.key(),
+        user: user,
         channel: channel,
     });
 
     Ok(())
 }
 
-fn _unsubscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, channel: Pubkey) -> Result<()> {
+fn _unsubscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, user: Pubkey, channel: Pubkey) -> Result<()> {
     require!(subscription_storage.is_subscribed == true, PushCommError::NotSubscribed);
 
     // Decrease user subscribe count
@@ -245,7 +245,7 @@ fn _unsubscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &
     subscription_storage.is_subscribed = false;
 
     emit!(Unsubscribed {
-        user: user_storage.key(),
+        user: user,
         channel: channel,
     });
 

--- a/programs/push_comm/src/lib.rs
+++ b/programs/push_comm/src/lib.rs
@@ -226,36 +226,39 @@ fn _add_user(user_storage: &mut Account<UserStorage>, comm_storage: &mut Account
 }
 
 fn _subscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, user: Pubkey, channel: Pubkey) -> Result<()> {
-    require!(subscription_storage.is_subscribed == false, PushCommError::AlreadySubscribed);
+    if !subscription_storage.is_subscribed {
 
-    // Increase user subscribe count by check overflow
-    user_storage.user_subscribe_count += 1;
-    // Mark user as subscribed for a given channel
-    subscription_storage.is_subscribed = true;
+        // Increase user subscribe count by check overflow
+        user_storage.user_subscribe_count += 1;
+        // Mark user as subscribed for a given channel
+        subscription_storage.is_subscribed = true;
 
-    emit!(Subscribed {
-        user: user,
-        channel: channel,
-    });
+        emit!(Subscribed {
+            user: user,
+            channel: channel,
+        });
+    }
 
     Ok(())
 }
 
 fn _unsubscribe(user_storage: &mut Account<UserStorage>, subscription_storage: &mut Account<Subscription>, user: Pubkey, channel: Pubkey) -> Result<()> {
-    require!(subscription_storage.is_subscribed == true, PushCommError::NotSubscribed);
+    if subscription_storage.is_subscribed {
 
-    // Decrease user subscribe count
-    user_storage.user_subscribe_count = user_storage
-    .user_subscribe_count
-    .checked_sub(1)
-    .ok_or(PushCommError::Underflow)?;
-    // Mark user as unsubscribed for a given channel
-    subscription_storage.is_subscribed = false;
+        // Decrease user subscribe count
+        user_storage.user_subscribe_count = user_storage
+        .user_subscribe_count
+        .checked_sub(1)
+        .ok_or(PushCommError::Underflow)?;
+        // Mark user as unsubscribed for a given channel
+        subscription_storage.is_subscribed = false;
 
-    emit!(Unsubscribed {
-        user: user,
-        channel: channel,
-    });
+        emit!(Unsubscribed {
+            user: user,
+            channel: channel,
+        });
+
+    }
 
     Ok(())
 }

--- a/programs/push_comm/src/state.rs
+++ b/programs/push_comm/src/state.rs
@@ -42,7 +42,7 @@ pub struct UserNotificationSettings{
 
 // Constant States
     pub const NAME: &str = "Push Comm V3"; // Check if this is actually needed
-    pub const CHAIN_NAME: &str = "Solana Mainnet"; 
+    pub const CHAIN_NAME: &str = "SOLANA"; 
     pub const MAX_NOTIF_SETTINGS_LENGTH: usize = 100; // Adjust as needed
 
 // Constants for Seeds

--- a/programs/push_comm/src/state.rs
+++ b/programs/push_comm/src/state.rs
@@ -7,7 +7,7 @@ use anchor_lang::prelude::*;
 pub struct PushCommStorageV3 {
     pub governance: Pubkey,
     pub push_channel_admin: Pubkey,
-    pub chain_cluster: String, // localnet, devnet or mainnet
+    pub chain_cluster: String, // devnet, testnet or mainnet-beta
     pub user_count: u64,
     pub push_token_ntt: Pubkey,
     pub paused: bool,

--- a/programs/push_comm/src/state.rs
+++ b/programs/push_comm/src/state.rs
@@ -9,7 +9,6 @@ pub struct PushCommStorageV3 {
     pub push_channel_admin: Pubkey,
     pub chain_id: u64,
     pub user_count: u64,
-    pub push_core_address: Pubkey,
     pub push_token_ntt: Pubkey,
     pub paused: bool,
 }

--- a/programs/push_comm/src/state.rs
+++ b/programs/push_comm/src/state.rs
@@ -7,7 +7,7 @@ use anchor_lang::prelude::*;
 pub struct PushCommStorageV3 {
     pub governance: Pubkey,
     pub push_channel_admin: Pubkey,
-    pub chain_id: u64,
+    pub chain_cluster: String, // localnet, devnet or mainnet
     pub user_count: u64,
     pub push_token_ntt: Pubkey,
     pub paused: bool,

--- a/tests/admin_actions.test.ts
+++ b/tests/admin_actions.test.ts
@@ -85,10 +85,10 @@ describe("push_comm_admin_setter_functions", () => {
   it("Is initialized!", async () => {
 
     const [storage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
-    const chainId = new anchor.BN(1);
+    const chainCluster = "devnet";
     const tx = await program.methods.initialize(
       pushAdmin.publicKey,
-      chainId,
+      chainCluster,
     ).accounts({
       storage: storage,
       signer: pushAdmin.publicKey,
@@ -100,7 +100,7 @@ describe("push_comm_admin_setter_functions", () => {
     // Fetch the initialized account and check initial values
     const accountData = await program.account.pushCommStorageV3.fetch(storage);
 
-    expect(accountData.chainId.toString()).to.equal(chainId.toString());
+    expect(accountData.chainCluster.toString()).to.equal(chainCluster.toString());
     expect(accountData.governance.toString()).to.eq(pushAdmin.publicKey.toString());
     expect(accountData.pushChannelAdmin.toString()).to.eq(pushAdmin.publicKey.toString());
 

--- a/tests/notif_settings.test.ts
+++ b/tests/notif_settings.test.ts
@@ -116,10 +116,10 @@ describe("push_comm_subscription_tests", () => {
   it("Is initialized!", async () => {
 
     const [storage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
-    const chainId = new anchor.BN(1);
+    const chainCluster = "devnet";
     const tx = await program.methods.initialize(
       pushAdmin.publicKey,
-      chainId,
+      chainCluster,
     ).accounts({
       storage: storage,
       signer: pushAdmin.publicKey,
@@ -129,7 +129,7 @@ describe("push_comm_subscription_tests", () => {
     // Fetch the initialized account and check initial values
     const accountData = await program.account.pushCommStorageV3.fetch(storage);
 
-    expect(accountData.chainId.toString()).to.equal(chainId.toString());
+    expect(accountData.chainCluster.toString()).to.equal(chainCluster.toString());
     expect(accountData.governance.toString()).to.eq(pushAdmin.publicKey.toString());
     expect(accountData.pushChannelAdmin.toString()).to.eq(pushAdmin.publicKey.toString());
 

--- a/tests/notification.test.ts
+++ b/tests/notification.test.ts
@@ -114,10 +114,10 @@ describe("push_comm_subscription_tests", () => {
   it("Is initialized!", async () => {
 
     const [storage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
-    const chainId = new anchor.BN(1);
+    const chainCluster = "devnet";
     const tx = await program.methods.initialize(
       pushAdmin.publicKey,
-      chainId,
+      chainCluster,
     ).accounts({
       storage: storage,
       signer: pushAdmin.publicKey,
@@ -127,7 +127,7 @@ describe("push_comm_subscription_tests", () => {
     // Fetch the initialized account and check initial values
     const accountData = await program.account.pushCommStorageV3.fetch(storage);
 
-    expect(accountData.chainId.toString()).to.equal(chainId.toString());
+    expect(accountData.chainCluster.toString()).to.equal(chainCluster.toString());
     expect(accountData.governance.toString()).to.eq(pushAdmin.publicKey.toString());
     expect(accountData.pushChannelAdmin.toString()).to.eq(pushAdmin.publicKey.toString());
 

--- a/tests/notification.test.ts
+++ b/tests/notification.test.ts
@@ -147,10 +147,17 @@ describe("push_comm_subscription_tests", () => {
     it("Channel1 adds delegate1", async () => {
       const [delegateStroage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
 
+      const [storageAccount, bump2nd] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount, bump1st] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount, bump3rd] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+          
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -164,11 +171,17 @@ describe("push_comm_subscription_tests", () => {
 
     it("Channel1 removes delegate1", async () => {
       const [delegateStroage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
+      const [storageAccount, bump2nd] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount, bump1st] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount, bump3rd] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
 
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -182,6 +195,9 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.removeDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -196,10 +212,19 @@ describe("push_comm_subscription_tests", () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
       const [delegateStroage2nd] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate2.publicKey.toBuffer()], program.programId);
 
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount1] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount1] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+      const [delegateStorageAccount2] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate2.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount2] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate2.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount1,
+        subscription: subscriptionAccount1,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
     
@@ -207,6 +232,9 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.addDelegate(delegate2.publicKey).accounts({
         storage: delegateStroage2nd,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount2,
+        subscription: subscriptionAccount2,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -226,10 +254,19 @@ describe("push_comm_subscription_tests", () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
       const [delegateStroage2nd] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate2.publicKey.toBuffer()], program.programId);
 
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount1] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount1] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+      const [delegateStorageAccount2] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate2.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount2] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate2.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount1,
+        subscription: subscriptionAccount1,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
     
@@ -237,6 +274,9 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.addDelegate(delegate2.publicKey).accounts({
         storage: delegateStroage2nd,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount2,
+        subscription: subscriptionAccount2,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -255,12 +295,18 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.removeDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount1,
+        subscription: subscriptionAccount1,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
       await program.methods.removeDelegate(delegate2.publicKey).accounts({
         storage: delegateStroage2nd,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount2,
+        subscription: subscriptionAccount2,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -278,14 +324,19 @@ describe("push_comm_subscription_tests", () => {
 
     it("Channel1 adds - removes - adds back delegate1", async () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
 
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
-    
 
       // Fetch the delegate_storage account to verify the delegate addition
       const delegateStorageData = await program.account.delegatedNotificationSenders.fetch(delegateStroage);
@@ -296,6 +347,9 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.removeDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -309,6 +363,9 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -321,11 +378,17 @@ describe("push_comm_subscription_tests", () => {
 
     it("Channel1 tries adding delegate1 twice", async () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
 
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
     
@@ -339,6 +402,9 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.addDelegate(delegate1.publicKey).accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
 
@@ -359,11 +425,17 @@ describe("push_comm_subscription_tests", () => {
         [SEEDS.DELEGATE, channel1.publicKey.toBuffer(), channel1.publicKey.toBuffer()],
         program.programId
       );
-    
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, channel1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, channel1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+
       // First attempt to add channel1 as its own delegate
       await program.methods.addDelegate(channel1.publicKey).accounts({
         storage: delegateStorage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
     
@@ -372,6 +444,9 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.addDelegate(channel1.publicKey).accounts({
           storage: delegateStorage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
     
@@ -388,11 +463,17 @@ describe("push_comm_subscription_tests", () => {
 
     it("Channel1 tries removing delegate1 twice", async () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
 
       // Initialize delegate_storage by adding delegate1
       await program.methods.addDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
 
@@ -400,6 +481,9 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.removeDelegate(delegate1.publicKey).accounts({
         storage: delegateStroage,
         signer: channel1.publicKey,
+        commStorage: storageAccount,
+        delegateStorage: delegateStorageAccount,
+        subscription: subscriptionAccount,
         systemProgram: anchor.web3.SystemProgram.programId,
       }).signers([channel1]).rpc();
     
@@ -407,6 +491,9 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.removeDelegate(delegate1.publicKey).accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
 
@@ -424,6 +511,9 @@ describe("push_comm_subscription_tests", () => {
 
     it("Adding a delegate should EMIT accurate event", async () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
       
        let addDelegateEvent: any = null;
 
@@ -434,6 +524,9 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.addDelegate(delegate1.publicKey).accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
 
@@ -448,11 +541,17 @@ describe("push_comm_subscription_tests", () => {
 
     it("Removing a delegate should EMIT accurate event", async () => {
       const [delegateStroage] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
+      const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+      const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+      const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
 
         // Initialize delegate_storage by adding delegate1
         await program.methods.addDelegate(delegate1.publicKey).accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
        let removeDelegateEvent: any = null;
@@ -464,6 +563,9 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.removeDelegate(delegate1.publicKey).accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,}).signers([channel1]).rpc();
 
          await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -490,12 +592,18 @@ describe("push_comm_subscription_tests", () => {
 
       it("Notification to USER1 by delegate1 for Channel 1", async () => {
         const [delegateStroage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()], program.programId);
-        
+        const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+        const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+        const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+
                 // Initialize delegate_storage by adding delegate
         await program.methods.addDelegate(delegate1.publicKey)
         .accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         })
         .signers([channel1])
@@ -532,12 +640,18 @@ describe("push_comm_subscription_tests", () => {
 
       it("Notification to USER1 by Channel1 for Channel 1", async () => {
         const [delegateStroage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.DELEGATE, channel1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
+        const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+        const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, channel1.publicKey.toBuffer()], program.programId);
+        const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, channel1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
         
                 // Initialize delegate_storage by adding delegate
         await program.methods.addDelegate(channel1.publicKey)
         .accounts({
           storage: delegateStroage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         })
         .signers([channel1])
@@ -577,11 +691,17 @@ describe("push_comm_subscription_tests", () => {
           [SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()],
           program.programId
         );
+        const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+        const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+        const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
       
         // Authorize delegate1 for channel1
         await program.methods.addDelegate(delegate1.publicKey).accounts({
           storage: delegateStorage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
       
@@ -644,11 +764,17 @@ describe("push_comm_subscription_tests", () => {
           [SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()],
           program.programId
         );
+        const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+        const [delegateStorageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+        const [subscriptionAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
       
         // Initialize delegate_storage by adding delegate1
         await program.methods.addDelegate(delegate1.publicKey).accounts({
           storage: delegateStorage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
       
@@ -656,6 +782,9 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.removeDelegate(delegate1.publicKey).accounts({
           storage: delegateStorage,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount,
+          subscription: subscriptionAccount,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
       
@@ -691,22 +820,33 @@ describe("push_comm_subscription_tests", () => {
           [SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate1.publicKey.toBuffer()],
           program.programId
         );
+        const [storageAccount] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
+        const [delegateStorageAccount1] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate1.publicKey.toBuffer()], program.programId);
+        const [subscriptionAccount1] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate1.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
       
         const [delegateStorage2] = await anchor.web3.PublicKey.findProgramAddressSync(
           [SEEDS.DELEGATE, channel1.publicKey.toBuffer(), delegate2.publicKey.toBuffer()],
           program.programId
         );
+        const [delegateStorageAccount2] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.USER_STORAGE, delegate2.publicKey.toBuffer()], program.programId);
+        const [subscriptionAccount2] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.SUBSCRIPTION, delegate2.publicKey.toBuffer(), channel1.publicKey.toBuffer()], program.programId);
       
         // Step 1: Add delegate1 and delegate2 for channel1
         await program.methods.addDelegate(delegate1.publicKey).accounts({
           storage: delegateStorage1,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount1,
+          subscription: subscriptionAccount1,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
       
         await program.methods.addDelegate(delegate2.publicKey).accounts({
           storage: delegateStorage2,
           signer: channel1.publicKey,
+          commStorage: storageAccount,
+          delegateStorage: delegateStorageAccount2,
+          subscription: subscriptionAccount2,
           systemProgram: anchor.web3.SystemProgram.programId,
         }).signers([channel1]).rpc();
       

--- a/tests/subscription.test.ts
+++ b/tests/subscription.test.ts
@@ -105,10 +105,10 @@ describe("push_comm_subscription_tests", () => {
   it("Is initialized!", async () => {
 
     const [storage, bump] = await anchor.web3.PublicKey.findProgramAddressSync([SEEDS.PUSH_COMM_STORAGE], program.programId);
-    const chainId = new anchor.BN(1);
+    const chainCluster = "devnet";
     const tx = await program.methods.initialize(
       pushAdmin.publicKey,
-      chainId,
+      chainCluster,
     ).accounts({
       storage: storage,
       signer: pushAdmin.publicKey,
@@ -118,7 +118,7 @@ describe("push_comm_subscription_tests", () => {
     // Fetch the initialized account and check initial values
     const accountData = await program.account.pushCommStorageV3.fetch(storage);
 
-    expect(accountData.chainId.toString()).to.equal(chainId.toString());
+    expect(accountData.chainCluster.toString()).to.equal(chainCluster.toString());
     expect(accountData.governance.toString()).to.eq(pushAdmin.publicKey.toString());
     expect(accountData.pushChannelAdmin.toString()).to.eq(pushAdmin.publicKey.toString());
 

--- a/tests/subscription.test.ts
+++ b/tests/subscription.test.ts
@@ -147,7 +147,6 @@ describe("push_comm_subscription_tests", () => {
           const tx = await program.methods.subscribe(channel1.publicKey).accounts({
               storage: userStorageAccount,
               subscription: subscriptionAccount,
-              channel: channel1.publicKey,
               commStorage: storageAccount,
               signer: user1.publicKey,
               systemProgram: anchor.web3.SystemProgram.programId,
@@ -186,7 +185,6 @@ describe("push_comm_subscription_tests", () => {
           await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccount,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -213,7 +211,6 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccount,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -224,7 +221,6 @@ describe("push_comm_subscription_tests", () => {
           await program.methods.subscribe(channel1.publicKey).accounts({
             storage: userStorageAccount,
             subscription: subscriptionAccount,
-            channel: channel1.publicKey,
             commStorage: storageAccount,
             signer: user1.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
@@ -261,7 +257,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccount,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -280,7 +275,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.unsubscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccount,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -306,7 +300,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
         storage: userStorageAccount,
         subscription: subscriptionAccount,
-        channel: channel1.publicKey,
         commStorage: storageAccount,
         signer: user1.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
@@ -323,7 +316,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.unsubscribe(channel1.publicKey).accounts({
         storage: userStorageAccount,
         subscription: subscriptionAccount,
-        channel: channel1.publicKey,
         commStorage: storageAccount,
         signer: user1.publicKey,
         systemProgram: anchor.web3.SystemProgram.programId,
@@ -351,7 +343,6 @@ describe("push_comm_subscription_tests", () => {
         await program.methods.unsubscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccount,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -387,7 +378,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountFirst,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -397,7 +387,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel2.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountSecond,
-          channel: channel2.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -407,7 +396,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel3.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountThird,
-          channel: channel3.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -441,7 +429,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountFirst,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -451,7 +438,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel2.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountSecond,
-          channel: channel2.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -461,7 +447,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel3.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountThird,
-          channel: channel3.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -482,7 +467,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.unsubscribe(channel1.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountFirst,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -492,7 +476,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.unsubscribe(channel2.publicKey).accounts({
           storage: userStorageAccount,
           subscription: subscriptionAccountSecond,
-          channel: channel2.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -526,7 +509,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorage1st,
           subscription: subscriptionAccountFirst,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user1.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -536,7 +518,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorage2nd,
           subscription: subscriptionAccountSecond,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user2.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,
@@ -546,7 +527,6 @@ describe("push_comm_subscription_tests", () => {
       await program.methods.subscribe(channel1.publicKey).accounts({
           storage: userStorage3rd,
           subscription: subscriptionAccountThird,
-          channel: channel1.publicKey,
           commStorage: storageAccount,
           signer: user3.publicKey,
           systemProgram: anchor.web3.SystemProgram.programId,


### PR DESCRIPTION
Modifications TLDR:
1. Added _subscribe private helper fn
2. Added _unsubscribe private helper fn
3. Removed channel account from SubscriptionContext
4. Added subscribe functionality in addDelegate fn (delegate subscribes to the channel)
5. Removed reverts of subscribe and unsubscribe when user is already subscribed and not subscribed respectively (making it consistent with EVM)
6. Removed set_core_address fn and core_address from storage
7. Improved send_notification fn to allow a channel to send notif without adding itself as a delegate
8. Modified CHAIN_NAME constant to `SOLANA` instead of `Solana Mainnet` to make it consistent with EVM practices
9. Added caller key in the ChannelAlias event
10. Modified `chain_id` to `chain_cluster` parameter which will have one of the following: (`devnet`, `testnet`, `mainnet-beta`) coz solana has concept of clusters instead of chain ids